### PR TITLE
Serve js.map files as assets.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -35,6 +35,7 @@ export default {
 
   assetExtensions: [
     'js',
+    'js.map',
     'css',
     'png',
     'jpe?g',


### PR DESCRIPTION
Enables SourceMaps to work properly. Fixes Issue #4 
